### PR TITLE
feat: add image upload to admin products

### DIFF
--- a/frontend/src/features/admin/AdminProducts.jsx
+++ b/frontend/src/features/admin/AdminProducts.jsx
@@ -1,10 +1,18 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { listProducts, createProduct, updateProduct, deleteProduct } from '../../api/products.js'
 const currency = (n)=> new Intl.NumberFormat('th-TH',{style:'currency', currency:'THB'}).format(n||0)
 
 export default function AdminProducts(){
   const [items, setItems] = useState([])
-  const [draft, setDraft] = useState({ name:'', category:'veg', price:0, unit:'กก.', stock:0, description:'', images:['🥬'], rating:4.5 })
+  const [draft, setDraft] = useState({ name:'', category:'veg', price:0, unit:'กก.', stock:0, description:'', images:[], rating:4.5 })
+  const fileRef = useRef()
+
+  const handleFile = file => {
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = e => setDraft(d=> ({...d, images:[e.target.result]}))
+    reader.readAsDataURL(file)
+  }
   const load = ()=> listProducts().then(res => setItems((res.items||[]).map(i=> ({...i, id:i._id||i.id}))))
   useEffect(()=>{ load() }, [])
   return (
@@ -12,6 +20,25 @@ export default function AdminProducts(){
       <h3>สินค้า</h3>
       <div className="card">
         <div style={{display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(140px,1fr))',gap:8}}>
+          <div
+            style={{
+              border:'2px dashed #ccc',
+              borderRadius:8,
+              width:120,
+              height:120,
+              display:'grid',
+              placeItems:'center',
+              cursor:'pointer'
+            }}
+            onClick={()=>fileRef.current?.click()}
+            onDragOver={e=>e.preventDefault()}
+            onDrop={e=>{e.preventDefault(); handleFile(e.dataTransfer.files?.[0])}}
+          >
+            {draft.images[0]
+              ? <img src={draft.images[0]} alt="preview" style={{width:'100%',height:'100%',objectFit:'cover',borderRadius:6}}/>
+              : <span style={{textAlign:'center',fontSize:12,color:'#666'}}>Drop image or click</span>}
+            <input ref={fileRef} type="file" accept="image/*" style={{display:'none'}} onChange={e=>handleFile(e.target.files?.[0])} />
+          </div>
           <input className="input" placeholder="ชื่อสินค้า" value={draft.name} onChange={e=>setDraft({...draft, name:e.target.value})}/>
           <select className="input" value={draft.category} onChange={e=>setDraft({...draft, category:e.target.value})}>
             <option value="veg">ผักสด</option><option value="fruit">ผลไม้</option><option value="herb">พืช/สมุนไพร</option>
@@ -19,16 +46,17 @@ export default function AdminProducts(){
           <input className="input" type="number" placeholder="ราคา" value={draft.price} onChange={e=>setDraft({...draft, price:Number(e.target.value)})}/>
           <input className="input" placeholder="หน่วย" value={draft.unit} onChange={e=>setDraft({...draft, unit:e.target.value})}/>
           <input className="input" type="number" placeholder="สต็อก" value={draft.stock} onChange={e=>setDraft({...draft, stock:Number(e.target.value)})}/>
-          <button className="btn primary" disabled={!draft.name} onClick={async ()=>{ await createProduct(draft); setDraft({ name:'', category:'veg', price:0, unit:'กก.', stock:0, description:'', images:['🥬'], rating:4.5 }); load() }}>เพิ่มสินค้า</button>
+          <button className="btn primary" disabled={!draft.name} onClick={async ()=>{ await createProduct(draft); setDraft({ name:'', category:'veg', price:0, unit:'กก.', stock:0, description:'', images:[], rating:4.5 }); load() }}>เพิ่มสินค้า</button>
         </div>
       </div>
 
       <div className="card" style={{marginTop:12, overflow:'auto'}}>
         <table className="table">
-          <thead><tr><th>สินค้า</th><th>หมวด</th><th style={{textAlign:'right'}}>ราคา</th><th style={{textAlign:'right'}}>สต็อก</th><th>หน่วย</th><th>ลบ</th></tr></thead>
+          <thead><tr><th>รูป</th><th>สินค้า</th><th>หมวด</th><th style={{textAlign:'right'}}>ราคา</th><th style={{textAlign:'right'}}>สต็อก</th><th>หน่วย</th><th>ลบ</th></tr></thead>
           <tbody>
             {items.map(p=> (
               <tr key={p.id}>
+                <td>{p.images?.[0] ? <img src={p.images[0]} alt={p.name} style={{width:40,height:40,objectFit:'cover',borderRadius:4}}/> : '—'}</td>
                 <td>{p.name}</td>
                 <td>{p.category}</td>
                 <td style={{textAlign:'right'}}>{currency(p.price)}</td>

--- a/frontend/src/features/shop/VeggieShopMVP.jsx
+++ b/frontend/src/features/shop/VeggieShopMVP.jsx
@@ -149,7 +149,7 @@ export default function VeggieShopMVP({ onOpenAuth }){
         <div className="product-grid">
           {s.products.map(p=> (
             <div key={p.id} className="card product-card">
-              <div className="product-image">{p.images?.[0]||'🥬'}</div>
+              <div className="product-image">{p.images?.[0] ? <img src={p.images[0]} alt={p.name} /> : '🥬'}</div>
               <div className="product-info">
                 <div className="product-title-row">
                   <b style={{fontSize:16}}>{p.name}</b>
@@ -244,10 +244,10 @@ export default function VeggieShopMVP({ onOpenAuth }){
               <div
                 style={{
                   fontSize: 28, background: '#f0fdf4', width: 44, height: 44,
-                  borderRadius: 10, display: 'grid', placeItems: 'center'
+                  borderRadius: 10, display: 'grid', placeItems: 'center', overflow:'hidden'
                 }}
               >
-                {ci.product.images?.[0] || '🥬'}
+                {ci.product.images?.[0] ? <img src={ci.product.images[0]} alt="" style={{width:'100%',height:'100%',objectFit:'cover'}}/> : '🥬'}
               </div>
               <div style={{ flex: 1 }}>
                 <div style={{ fontWeight: 700 }}>{ci.product.name}</div>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -71,6 +71,12 @@ a{color:inherit}button{cursor:pointer}input,select,button{font:inherit}
   font-size: 48px;
 }
 
+.product-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .product-info { padding: 12px; }
 .product-title-row { display: flex; align-items: center; gap: 8px; }
 .product-description { color: #555; font-size: 13px; margin-top: 4px; }


### PR DESCRIPTION
## Summary
- enable drag and drop image upload when creating products
- render product thumbnails in admin and shop views

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ff40026008325a1e6850d9460020d