### PR TITLE
feat: support product image uploads

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.6.0",
+    "multer": "^1.4.5-lts.1",
     "zod": "^3.23.8"
   }
 }

--- a/backend/src/models/Product.js
+++ b/backend/src/models/Product.js
@@ -6,7 +6,7 @@ const schema = new mongoose.Schema({
   unit:{type:String,default:'กก.'},
   price:{type:Number,default:0},
   stock:{type:Number,default:0},
-  images:[String],
+  images:{type:[String],default:[]},
   rating:Number
 },{timestamps:true})
 export default mongoose.model('Product', schema)

--- a/backend/src/routes/products.js
+++ b/backend/src/routes/products.js
@@ -2,9 +2,34 @@ import { Router } from 'express'
 import Product from '../models/Product.js'
 import auth from '../middleware/auth.js'
 import role from '../middleware/role.js'
+import multer from 'multer'
+import path from 'path'
+import fs from 'fs'
+
+const uploadDir = 'uploads'
+fs.mkdirSync(uploadDir, { recursive: true })
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, uploadDir),
+  filename: (_req, file, cb) => cb(null, Date.now() + path.extname(file.originalname))
+})
+const upload = multer({
+  storage,
+  limits: { fileSize: 5 * 1024 * 1024, files: 5 },
+  fileFilter: (_req, file, cb) => {
+    if (file.mimetype.startsWith('image/')) cb(null, true)
+    else cb(new Error('only image files'))
+  }
+})
+
 const router = Router()
 router.get('/', async (_req,res)=>{ const items = await Product.find().sort({createdAt:-1}).lean(); res.json({ items }) })
 router.post('/', auth, role('admin'), async (req,res)=>{ const item = await Product.create(req.body); res.json({ item }) })
+router.post('/upload', auth, role('admin'), upload.array('images', 5), (req,res)=>{
+  const files = req.files || []
+  if (!files.length) return res.status(400).json({ message:'no file' })
+  const urls = files.map(f => `${req.protocol}://${req.get('host')}/uploads/${f.filename}`)
+  res.json({ urls })
+})
 router.put('/:id', auth, role('admin'), async (req,res)=>{ const item = await Product.findByIdAndUpdate(req.params.id, req.body, { new:true }); if (!item) return res.status(404).json({ message:'not found' }); res.json({ item }) })
 router.delete('/:id', auth, role('admin'), async (req,res)=>{ const item = await Product.findByIdAndDelete(req.params.id); if (!item) return res.status(404).json({ message:'not found' }); res.json({ ok:true }) })
 export default router

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -24,6 +24,7 @@ app.use(express.json({ limit:'1mb' }))
 app.use(express.urlencoded({ extended:true }))
 app.use(cookieParser())
 app.use(mongoSanitize())
+app.use('/uploads', express.static('uploads'))
 
 app.get('/', (_req,res)=> res.json({ name:'vegshop-api' }))
 app.use('/health', health)

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -16,11 +16,18 @@ async function refresh(){
 
 export async function api(path, { method='GET', body } = {}){
   const doFetch = async ()=>{
-    const headers = { 'Content-Type':'application/json' }
+    const headers = {}
+    const isForm = body instanceof FormData
+    if (!isForm) headers['Content-Type'] = 'application/json'
     if (ACCESS_TOKEN) headers['Authorization'] = 'Bearer ' + ACCESS_TOKEN
     const legacy = localStorage.getItem('veg_token')
     if (!ACCESS_TOKEN && legacy) headers['Authorization'] = 'Bearer ' + legacy
-    const res = await fetch(BASE + path, { method, headers, body: body? JSON.stringify(body): undefined, credentials:'include' })
+    const res = await fetch(BASE + path, {
+      method,
+      headers,
+      body: body ? (isForm ? body : JSON.stringify(body)) : undefined,
+      credentials:'include'
+    })
     return res
   }
   let res = await doFetch()

--- a/frontend/src/api/products.js
+++ b/frontend/src/api/products.js
@@ -3,3 +3,8 @@ export const listProducts = () => api('/products')
 export const createProduct = (payload) => api('/products', { method:'POST', body: payload })
 export const updateProduct = (id, patch) => api(`/products/${id}`, { method:'PUT', body: patch })
 export const deleteProduct = (id) => api(`/products/${id}`, { method:'DELETE' })
+export const uploadProductImages = (files) => {
+  const data = new FormData()
+  for (const f of files) data.append('images', f)
+  return api('/products/upload', { method:'POST', body: data })
+}

--- a/frontend/src/features/admin/AdminProducts.jsx
+++ b/frontend/src/features/admin/AdminProducts.jsx
@@ -1,10 +1,22 @@
-import React, { useEffect, useState } from 'react'
-import { listProducts, createProduct, updateProduct, deleteProduct } from '../../api/products.js'
+import React, { useEffect, useRef, useState } from 'react'
+import { listProducts, createProduct, updateProduct, deleteProduct, uploadProductImages } from '../../api/products.js'
 const currency = (n)=> new Intl.NumberFormat('th-TH',{style:'currency', currency:'THB'}).format(n||0)
 
 export default function AdminProducts(){
   const [items, setItems] = useState([])
-  const [draft, setDraft] = useState({ name:'', category:'veg', price:0, unit:'กก.', stock:0, description:'', images:['🥬'], rating:4.5 })
+  const [draft, setDraft] = useState({ name:'', category:'veg', price:0, unit:'กก.', stock:0, description:'', images:[], rating:4.5 })
+  const [files, setFiles] = useState([])
+  const fileRef = useRef()
+
+  const handleFiles = list => {
+    const arr = Array.from(list || []).filter(f => f.type.startsWith('image/') && f.size <= 5 * 1024 * 1024)
+    if (!arr.length) return
+    setFiles(prev => {
+      const merged = [...prev, ...arr].slice(0,5)
+      setDraft(d => ({ ...d, images: merged.map(f => URL.createObjectURL(f)) }))
+      return merged
+    })
+  }
   const load = ()=> listProducts().then(res => setItems((res.items||[]).map(i=> ({...i, id:i._id||i.id}))))
   useEffect(()=>{ load() }, [])
   return (
@@ -12,6 +24,26 @@ export default function AdminProducts(){
       <h3>สินค้า</h3>
       <div className="card">
         <div style={{display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(140px,1fr))',gap:8}}>
+          <div
+            style={{
+              border:'2px dashed #ccc',
+              borderRadius:8,
+              width:120,
+              height:120,
+              display:'grid',
+              placeItems:'center',
+              cursor:'pointer'
+            }}
+            onClick={()=>fileRef.current?.click()}
+            onDragOver={e=>e.preventDefault()}
+            onDrop={e=>{e.preventDefault(); handleFiles(e.dataTransfer.files)}}
+            onPaste={e=>handleFiles(e.clipboardData.files)}
+          >
+            {draft.images.length
+              ? <img src={draft.images[0]} alt="preview" style={{width:'100%',height:'100%',objectFit:'cover',borderRadius:6}}/>
+              : <span style={{textAlign:'center',fontSize:12,color:'#666'}}>Drop/Paste or click<br/>image/* ≤5MB, max 5 files</span>}
+            <input ref={fileRef} type="file" accept="image/*" multiple style={{display:'none'}} onChange={e=>handleFiles(e.target.files)} />
+          </div>
           <input className="input" placeholder="ชื่อสินค้า" value={draft.name} onChange={e=>setDraft({...draft, name:e.target.value})}/>
           <select className="input" value={draft.category} onChange={e=>setDraft({...draft, category:e.target.value})}>
             <option value="veg">ผักสด</option><option value="fruit">ผลไม้</option><option value="herb">พืช/สมุนไพร</option>
@@ -19,16 +51,27 @@ export default function AdminProducts(){
           <input className="input" type="number" placeholder="ราคา" value={draft.price} onChange={e=>setDraft({...draft, price:Number(e.target.value)})}/>
           <input className="input" placeholder="หน่วย" value={draft.unit} onChange={e=>setDraft({...draft, unit:e.target.value})}/>
           <input className="input" type="number" placeholder="สต็อก" value={draft.stock} onChange={e=>setDraft({...draft, stock:Number(e.target.value)})}/>
-          <button className="btn primary" disabled={!draft.name} onClick={async ()=>{ await createProduct(draft); setDraft({ name:'', category:'veg', price:0, unit:'กก.', stock:0, description:'', images:['🥬'], rating:4.5 }); load() }}>เพิ่มสินค้า</button>
+            <button className="btn primary" disabled={!draft.name} onClick={async ()=>{
+              let images = []
+              if (files.length){
+                const uploaded = await uploadProductImages(files)
+                images = uploaded.urls
+              }
+              await createProduct({ ...draft, images })
+              setDraft({ name:'', category:'veg', price:0, unit:'กก.', stock:0, description:'', images:[], rating:4.5 })
+              setFiles([])
+              load()
+            }}>เพิ่มสินค้า</button>
         </div>
       </div>
 
       <div className="card" style={{marginTop:12, overflow:'auto'}}>
         <table className="table">
-          <thead><tr><th>สินค้า</th><th>หมวด</th><th style={{textAlign:'right'}}>ราคา</th><th style={{textAlign:'right'}}>สต็อก</th><th>หน่วย</th><th>ลบ</th></tr></thead>
+          <thead><tr><th>รูป</th><th>สินค้า</th><th>หมวด</th><th style={{textAlign:'right'}}>ราคา</th><th style={{textAlign:'right'}}>สต็อก</th><th>หน่วย</th><th>ลบ</th></tr></thead>
           <tbody>
             {items.map(p=> (
               <tr key={p.id}>
+                  <td>{p.images?.[0] ? <img src={p.images[0]} alt={p.name} style={{width:40,height:40,objectFit:'cover',borderRadius:4}}/> : '—'}</td>
                 <td>{p.name}</td>
                 <td>{p.category}</td>
                 <td style={{textAlign:'right'}}>{currency(p.price)}</td>

--- a/frontend/src/features/shop/VeggieShopMVP.jsx
+++ b/frontend/src/features/shop/VeggieShopMVP.jsx
@@ -149,7 +149,7 @@ export default function VeggieShopMVP({ onOpenAuth }){
         <div className="product-grid">
           {s.products.map(p=> (
             <div key={p.id} className="card product-card">
-              <div className="product-image">{p.images?.[0]||'🥬'}</div>
+              <div className="product-image">{p.images?.[0] ? <img src={p.images[0]} alt={p.name} /> : '🥬'}</div>
               <div className="product-info">
                 <div className="product-title-row">
                   <b style={{fontSize:16}}>{p.name}</b>
@@ -244,10 +244,10 @@ export default function VeggieShopMVP({ onOpenAuth }){
               <div
                 style={{
                   fontSize: 28, background: '#f0fdf4', width: 44, height: 44,
-                  borderRadius: 10, display: 'grid', placeItems: 'center'
+                  borderRadius: 10, display: 'grid', placeItems: 'center', overflow:'hidden'
                 }}
               >
-                {ci.product.images?.[0] || '🥬'}
+                {ci.product.images?.[0] ? <img src={ci.product.images[0]} alt="" style={{width:'100%',height:'100%',objectFit:'cover'}}/> : '🥬'}
               </div>
               <div style={{ flex: 1 }}>
                 <div style={{ fontWeight: 700 }}>{ci.product.name}</div>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -71,6 +71,12 @@ a{color:inherit}button{cursor:pointer}input,select,button{font:inherit}
   font-size: 48px;
 }
 
+.product-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .product-info { padding: 12px; }
 .product-title-row { display: flex; align-items: center; gap: 8px; }
 .product-description { color: #555; font-size: 13px; margin-top: 4px; }


### PR DESCRIPTION
## Summary
- allow admins to paste or drop up to five images when creating products
- persist multiple product image URLs and serve them from the backend
- render the first stored image for products in the shop and admin tables

## Testing
- `npm install` (backend) *(failed: 403 Forbidden)*
- `npm test` (backend) *(missing script)*
- `npm test` (frontend) *(missing script)*
- `npm run build` (frontend) *(failed: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_689ff40026008325a1e6850d9460020d