### PR TITLE
feat: support product image uploads

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.6.0",
+    "multer": "^1.4.5-lts.1",
     "zod": "^3.23.8"
   }
 }

--- a/backend/src/models/Product.js
+++ b/backend/src/models/Product.js
@@ -5,8 +5,9 @@ const schema = new mongoose.Schema({
   category:{type:String,enum:['veg','fruit','herb'],default:'veg'},
   unit:{type:String,default:'กก.'},
   price:{type:Number,default:0},
+  originalPrice:Number,
   stock:{type:Number,default:0},
-  images:[String],
+  images:{type:[String],default:[]},
   rating:Number
 },{timestamps:true})
 export default mongoose.model('Product', schema)

--- a/backend/src/routes/products.js
+++ b/backend/src/routes/products.js
@@ -2,9 +2,34 @@ import { Router } from 'express'
 import Product from '../models/Product.js'
 import auth from '../middleware/auth.js'
 import role from '../middleware/role.js'
+import multer from 'multer'
+import path from 'path'
+import fs from 'fs'
+
+const uploadDir = 'uploads'
+fs.mkdirSync(uploadDir, { recursive: true })
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, uploadDir),
+  filename: (_req, file, cb) => cb(null, Date.now() + path.extname(file.originalname))
+})
+const upload = multer({
+  storage,
+  limits: { fileSize: 5 * 1024 * 1024, files: 5 },
+  fileFilter: (_req, file, cb) => {
+    if (file.mimetype.startsWith('image/')) cb(null, true)
+    else cb(new Error('only image files'))
+  }
+})
+
 const router = Router()
 router.get('/', async (_req,res)=>{ const items = await Product.find().sort({createdAt:-1}).lean(); res.json({ items }) })
 router.post('/', auth, role('admin'), async (req,res)=>{ const item = await Product.create(req.body); res.json({ item }) })
+router.post('/upload', auth, role('admin'), upload.array('images', 5), (req,res)=>{
+  const files = req.files || []
+  if (!files.length) return res.status(400).json({ message:'no file' })
+  const urls = files.map(f => `${req.protocol}://${req.get('host')}/uploads/${f.filename}`)
+  res.json({ urls })
+})
 router.put('/:id', auth, role('admin'), async (req,res)=>{ const item = await Product.findByIdAndUpdate(req.params.id, req.body, { new:true }); if (!item) return res.status(404).json({ message:'not found' }); res.json({ item }) })
 router.delete('/:id', auth, role('admin'), async (req,res)=>{ const item = await Product.findByIdAndDelete(req.params.id); if (!item) return res.status(404).json({ message:'not found' }); res.json({ ok:true }) })
 export default router

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -24,6 +24,7 @@ app.use(express.json({ limit:'1mb' }))
 app.use(express.urlencoded({ extended:true }))
 app.use(cookieParser())
 app.use(mongoSanitize())
+app.use('/uploads', express.static('uploads'))
 
 app.get('/', (_req,res)=> res.json({ name:'vegshop-api' }))
 app.use('/health', health)

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -16,11 +16,18 @@ async function refresh(){
 
 export async function api(path, { method='GET', body } = {}){
   const doFetch = async ()=>{
-    const headers = { 'Content-Type':'application/json' }
+    const headers = {}
+    const isForm = body instanceof FormData
+    if (!isForm) headers['Content-Type'] = 'application/json'
     if (ACCESS_TOKEN) headers['Authorization'] = 'Bearer ' + ACCESS_TOKEN
     const legacy = localStorage.getItem('veg_token')
     if (!ACCESS_TOKEN && legacy) headers['Authorization'] = 'Bearer ' + legacy
-    const res = await fetch(BASE + path, { method, headers, body: body? JSON.stringify(body): undefined, credentials:'include' })
+    const res = await fetch(BASE + path, {
+      method,
+      headers,
+      body: body ? (isForm ? body : JSON.stringify(body)) : undefined,
+      credentials:'include'
+    })
     return res
   }
   let res = await doFetch()

--- a/frontend/src/api/products.js
+++ b/frontend/src/api/products.js
@@ -3,3 +3,8 @@ export const listProducts = () => api('/products')
 export const createProduct = (payload) => api('/products', { method:'POST', body: payload })
 export const updateProduct = (id, patch) => api(`/products/${id}`, { method:'PUT', body: patch })
 export const deleteProduct = (id) => api(`/products/${id}`, { method:'DELETE' })
+export const uploadProductImages = (files) => {
+  const data = new FormData()
+  for (const f of files) data.append('images', f)
+  return api('/products/upload', { method:'POST', body: data })
+}

--- a/frontend/src/features/admin/AdminProducts.jsx
+++ b/frontend/src/features/admin/AdminProducts.jsx
@@ -1,10 +1,22 @@
-import React, { useEffect, useState } from 'react'
-import { listProducts, createProduct, updateProduct, deleteProduct } from '../../api/products.js'
+import React, { useEffect, useRef, useState } from 'react'
+import { listProducts, createProduct, updateProduct, deleteProduct, uploadProductImages } from '../../api/products.js'
 const currency = (n)=> new Intl.NumberFormat('th-TH',{style:'currency', currency:'THB'}).format(n||0)
 
 export default function AdminProducts(){
   const [items, setItems] = useState([])
-  const [draft, setDraft] = useState({ name:'', category:'veg', price:0, unit:'กก.', stock:0, description:'', images:['🥬'], rating:4.5 })
+  const [draft, setDraft] = useState({ name:'', category:'veg', price:0, originalPrice:0, unit:'กก.', stock:0, description:'', images:[], rating:4.5 })
+  const [files, setFiles] = useState([])
+  const fileRef = useRef()
+
+  const handleFiles = list => {
+    const arr = Array.from(list || []).filter(f => f.type.startsWith('image/') && f.size <= 5 * 1024 * 1024)
+    if (!arr.length) return
+    setFiles(prev => {
+      const merged = [...prev, ...arr].slice(0,5)
+      setDraft(d => ({ ...d, images: merged.map(f => URL.createObjectURL(f)) }))
+      return merged
+    })
+  }
   const load = ()=> listProducts().then(res => setItems((res.items||[]).map(i=> ({...i, id:i._id||i.id}))))
   useEffect(()=>{ load() }, [])
   return (
@@ -12,26 +24,59 @@ export default function AdminProducts(){
       <h3>สินค้า</h3>
       <div className="card">
         <div style={{display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(140px,1fr))',gap:8}}>
+          <div
+            style={{
+              border:'2px dashed #ccc',
+              borderRadius:8,
+              width:120,
+              height:120,
+              display:'grid',
+              placeItems:'center',
+              cursor:'pointer'
+            }}
+            onClick={()=>fileRef.current?.click()}
+            onDragOver={e=>e.preventDefault()}
+            onDrop={e=>{e.preventDefault(); handleFiles(e.dataTransfer.files)}}
+            onPaste={e=>handleFiles(e.clipboardData.files)}
+          >
+            {draft.images.length
+              ? <img src={draft.images[0]} alt="preview" style={{width:'100%',height:'100%',objectFit:'cover',borderRadius:6}}/>
+              : <span style={{textAlign:'center',fontSize:12,color:'#666'}}>Drop/Paste or click<br/>image/* ≤5MB, max 5 files</span>}
+            <input ref={fileRef} type="file" accept="image/*" multiple style={{display:'none'}} onChange={e=>handleFiles(e.target.files)} />
+          </div>
           <input className="input" placeholder="ชื่อสินค้า" value={draft.name} onChange={e=>setDraft({...draft, name:e.target.value})}/>
           <select className="input" value={draft.category} onChange={e=>setDraft({...draft, category:e.target.value})}>
             <option value="veg">ผักสด</option><option value="fruit">ผลไม้</option><option value="herb">พืช/สมุนไพร</option>
           </select>
-          <input className="input" type="number" placeholder="ราคา" value={draft.price} onChange={e=>setDraft({...draft, price:Number(e.target.value)})}/>
+          <input className="input" type="number" placeholder="ราคาโปรโมชัน" value={draft.price} onChange={e=>setDraft({...draft, price:Number(e.target.value)})}/>
+          <input className="input" type="number" placeholder="ราคาปกติ" value={draft.originalPrice} onChange={e=>setDraft({...draft, originalPrice:Number(e.target.value)})}/>
           <input className="input" placeholder="หน่วย" value={draft.unit} onChange={e=>setDraft({...draft, unit:e.target.value})}/>
           <input className="input" type="number" placeholder="สต็อก" value={draft.stock} onChange={e=>setDraft({...draft, stock:Number(e.target.value)})}/>
-          <button className="btn primary" disabled={!draft.name} onClick={async ()=>{ await createProduct(draft); setDraft({ name:'', category:'veg', price:0, unit:'กก.', stock:0, description:'', images:['🥬'], rating:4.5 }); load() }}>เพิ่มสินค้า</button>
+            <button className="btn primary" disabled={!draft.name} onClick={async ()=>{
+              let images = []
+              if (files.length){
+                const uploaded = await uploadProductImages(files)
+                images = uploaded.urls
+              }
+              await createProduct({ ...draft, images })
+              setDraft({ name:'', category:'veg', price:0, originalPrice:0, unit:'กก.', stock:0, description:'', images:[], rating:4.5 })
+              setFiles([])
+              load()
+            }}>เพิ่มสินค้า</button>
         </div>
       </div>
 
       <div className="card" style={{marginTop:12, overflow:'auto'}}>
         <table className="table">
-          <thead><tr><th>สินค้า</th><th>หมวด</th><th style={{textAlign:'right'}}>ราคา</th><th style={{textAlign:'right'}}>สต็อก</th><th>หน่วย</th><th>ลบ</th></tr></thead>
+          <thead><tr><th>รูป</th><th>สินค้า</th><th>หมวด</th><th style={{textAlign:'right'}}>ราคาโปรฯ</th><th style={{textAlign:'right'}}>ราคาปกติ</th><th style={{textAlign:'right'}}>สต็อก</th><th>หน่วย</th><th>ลบ</th></tr></thead>
           <tbody>
             {items.map(p=> (
               <tr key={p.id}>
+                  <td>{p.images?.[0] ? <img src={p.images[0]} alt={p.name} style={{width:40,height:40,objectFit:'cover',borderRadius:4}}/> : '—'}</td>
                 <td>{p.name}</td>
                 <td>{p.category}</td>
                 <td style={{textAlign:'right'}}>{currency(p.price)}</td>
+                <td style={{textAlign:'right'}}>{p.originalPrice?currency(p.originalPrice):'—'}</td>
                 <td style={{textAlign:'right'}}><input className="input" style={{width:80,textAlign:'right'}} type="number" defaultValue={p.stock} onBlur={async (e)=>{ await updateProduct(p.id, { stock:Number(e.target.value) }); load() }} /></td>
                 <td>{p.unit}</td>
                 <td><button className="btn" onClick={async ()=>{ if(confirm(`ลบสินค้า “${p.name}” ?`)){ await deleteProduct(p.id); load() } }}>ลบ</button></td>

--- a/frontend/src/features/shop/VeggieShopMVP.jsx
+++ b/frontend/src/features/shop/VeggieShopMVP.jsx
@@ -70,6 +70,7 @@ export default function VeggieShopMVP({ onOpenAuth }){
   const [showCart, setShowCart] = useState(false)
   const [showCheckout, setShowCheckout] = useState(false)
   const [ppOpen, setPpOpen] = useState(false); const [ppPayload, setPpPayload] = useState('')
+  const [viewer, setViewer] = useState({ open:false, images:[], index:0 })
 
   useEffect(()=>{ listProducts().then(r=>{
     const items=(r.items||[]).map(p=> ({...p, id:p._id||p.id}))
@@ -147,38 +148,46 @@ export default function VeggieShopMVP({ onOpenAuth }){
       {/* Grid สินค้า */}
       <div className="container" style={{marginTop:12}}>
         <div className="product-grid">
-          {s.products.map(p=> (
-            <div key={p.id} className="card product-card">
-              <div className="product-image">{p.images?.[0]||'🥬'}</div>
-              <div className="product-info">
-                <div className="product-title-row">
-                  <b style={{fontSize:16}}>{p.name}</b>
-                  <span className="badge">{p.category}</span>
-                </div>
-                <div className="product-description">{p.description}</div>
-                <div className="product-bottom-row">
-                  <div><b style={{fontSize:16}}>{currency(p.price)}</b> <span style={{fontSize:12,color:'#666'}}>/ {p.unit}</span></div>
-                  <button
-                    className="btn"
-                    disabled={p.stock<=0}
-                    onClick={()=>{ console.log('[Shop] add to cart', p.id); d({type:'ADD_TO_CART', id:p.id}) }}
-                    style={{
-                      background: p.stock>0? '#16a34a':'#e5e7eb',
-                      color: p.stock>0? '#fff':'#999',
-                      borderColor: p.stock>0? '#16a34a':'#e5e7eb',
-                      fontWeight:700
-                    }}
-                  >
-                    {p.stock>0?'ใส่ตะกร้า':'หมดสต็อก'}
-                  </button>
-                </div>
+          {s.products.map(p=> {
+            const discount = p.originalPrice && p.price < p.originalPrice ? Math.round(100 - (p.price / p.originalPrice) * 100) : 0
+            return (
+            <div key={p.id} className="card product-card simple">
+              <div className="product-image">
+                {p.images?.length ? (
+                  <img src={p.images[0]} alt={p.name} onClick={()=>setViewer({open:true, images:p.images, index:0})} />
+                ) : '🥬'}
+                {discount > 0 && <span className="discount-badge">-{discount}%</span>}
               </div>
-            </div>
-          ))}
+              <div className="product-info">
+                <div className="product-title">{p.name}</div>
+                <div className="price-row">
+                  <b>{currency(p.price)}</b>
+                  {discount>0 && <span className="old-price">{currency(p.originalPrice)}</span>}
+                </div>
+                <button
+                  className="btn add"
+                  disabled={p.stock<=0}
+                  onClick={()=>{ console.log('[Shop] add to cart', p.id); d({type:'ADD_TO_CART', id:p.id}) }}
+                >{p.stock>0?'ใส่ตะกร้า':'หมดสต็อก'}</button>
+              </div>
+            </div>)
+          })}
         </div>
       </div>
 
-      
+      {viewer.open && (
+        <div className="image-modal overlay" onClick={()=>setViewer(v=>({...v, open:false}))}>
+          {viewer.images.length>1 && (
+            <button className="nav prev" onClick={e=>{e.stopPropagation(); setViewer(v=>({...v, index:(v.index-1+v.images.length)%v.images.length}))}}>‹</button>
+          )}
+          <img src={viewer.images[viewer.index]} alt="preview" className="modal-pop" onClick={e=>e.stopPropagation()} />
+          {viewer.images.length>1 && (
+            <button className="nav next" onClick={e=>{e.stopPropagation(); setViewer(v=>({...v, index:(v.index+1)%v.images.length}))}}>›</button>
+          )}
+        </div>
+      )}
+
+
 {/* Drawer: Cart */}
 {showCart && (
   <div
@@ -244,10 +253,10 @@ export default function VeggieShopMVP({ onOpenAuth }){
               <div
                 style={{
                   fontSize: 28, background: '#f0fdf4', width: 44, height: 44,
-                  borderRadius: 10, display: 'grid', placeItems: 'center'
+                  borderRadius: 10, display: 'grid', placeItems: 'center', overflow:'hidden'
                 }}
               >
-                {ci.product.images?.[0] || '🥬'}
+                {ci.product.images?.[0] ? <img src={ci.product.images[0]} alt="" style={{width:'100%',height:'100%',objectFit:'cover'}}/> : '🥬'}
               </div>
               <div style={{ flex: 1 }}>
                 <div style={{ fontWeight: 700 }}>{ci.product.name}</div>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -63,15 +63,59 @@ a{color:inherit}button{cursor:pointer}input,select,button{font:inherit}
   box-shadow: 0 8px 24px rgba(0,0,0,.08);
 }
 
-.product-image {
+.product-card.simple .product-image {
   background: #f0fdf4;
   display: grid;
   place-items: center;
-  height: 120px;
+  height: 180px;
+  position: relative;
   font-size: 48px;
 }
 
-.product-info { padding: 12px; }
-.product-title-row { display: flex; align-items: center; gap: 8px; }
-.product-description { color: #555; font-size: 13px; margin-top: 4px; }
-.product-bottom-row { display: flex; justify-content: space-between; align-items: center; margin-top: 10px; }
+.product-card.simple .product-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  cursor: pointer;
+}
+
+.discount-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  background: #ef4444;
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.image-modal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,.8);
+  gap: 12px;
+}
+
+.image-modal img {
+  max-width: 90%;
+  max-height: 90%;
+  border-radius: 12px;
+}
+
+.image-modal .nav {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 32px;
+  cursor: pointer;
+  padding: 12px;
+}
+
+.product-card.simple .product-info { padding: 8px; display:flex; flex-direction:column; gap:4px; }
+.product-card.simple .product-title { font-size: 14px; height:36px; overflow:hidden; }
+.product-card.simple .price-row { color:#ef4444; display:flex; align-items:baseline; gap:6px; }
+.product-card.simple .old-price { color:#9ca3af; text-decoration:line-through; font-size:13px; }
+.product-card.simple .btn.add { margin-top:auto; background:#16a34a; color:#fff; border-color:#16a34a; }


### PR DESCRIPTION
## Summary
- allow admins to paste or drop up to five images when creating products
- persist multiple product image URLs and serve them from the backend
- render the first stored image for products in the shop and admin tables
- enable shoppers to scroll through product photos and open a full-size viewer
- capture original prices to show discounts and redesign product cards with sale badges

## Testing
- `npm install` (backend) *(failed: 403 Forbidden)*
- `npm test` (backend) *(missing script: "test")*
- `npm install` (frontend)
- `npm test` (frontend) *(missing script: "test")*
- `npm run build` (frontend) *(failed: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_689ff40026008325a1e6850d9460020d